### PR TITLE
Built preliminary manifestation system

### DIFF
--- a/data.json
+++ b/data.json
@@ -173,7 +173,7 @@
       "animation_key": "blade_circle",
       "cost": 25,
       "type": "tack",
-      "attack_delay": 20,
+      "attack_delay": 15,
       "icon_data": 16,
       "disable_icon_rotation": true
     },
@@ -199,7 +199,7 @@
       "animation_key": "hale_howitzer",
       "cost": 30,
       "type": "frontal",
-      "attack_delay": 30,
+      "attack_delay": 25,
       "icon_data": 20,
       "disable_icon_rotation": false
     },

--- a/src/data.lua
+++ b/src/data.lua
@@ -65,7 +65,16 @@ function reset_game()
   -- If true, selecting towers manifests them. If false, selecting towers sells them.
   manifest_mode = true
   -- If true, the player is currently manifesting a tower. Else, they aren't and the game functions as normal.
-  manifesting_now = true
+  manifesting_now = false
+  -- Where the player is manifesting (defaults to 0,0 but is set on selection)
+  manifest_location     = Vec:new(0, 0)
+  -- Only one of these can be true at one time. Affects game logic.
+  manifesting_sword     = false
+  manifesting_lightning = false
+  manifesting_hale      = false
+  manifesting_torch     = false
+  manifesting_sharp     = false
+
   -- Internal Data -- Don't modify
   enemy_current_spawn_tick = 0
   map_menu_enable, enemies_active, shop_enable, start_next_wave, wave_cor = true

--- a/src/tower.lua
+++ b/src/tower.lua
@@ -96,17 +96,64 @@ function place_tower(position)
 end
 
 function refund_tower_at(position)
-  if manifest_mode == false then
-    for tower in all(towers) do
-      if tower.position == position then
-        grid[position.y][position.x] = "empty"
-        if (tower.type == "floor") grid[position.y][position.x] = "path"
-        coins += tower.cost \ 2
-        del(animators, tower.animator) 
-        del(towers, tower)
+  for tower in all(towers) do
+    if tower.position == position then
+      grid[position.y][position.x] = "empty"
+      if (tower.type == "floor") grid[position.y][position.x] = "path"
+      coins += tower.cost \ 1.25
+      del(animators, tower.animator) 
+      del(towers, tower)
+     end
+  end
+end
+
+function manifest_tower_at(position)
+  for tower in all(towers) do
+    if tower.position == position then
+      manifesting_now = true
+      if (tower.name == "sword circle") then
+        manifesting_sword = true
+      elseif (tower.name == "lightning lance") then
+        manifesting_lightning = true
+      elseif (tower.name == "hale howitzer") then
+        manifesting_hale = true
+      elseif (tower.name == "torch trap") then
+        manifesting_torch = true
+      end
+      manifest_location = position
+    end
+  end
+end
+
+function unmanifest_tower()
+  manifesting_now = false
+  manifesting_sword = false
+  manifesting_lightning = false
+  manifesting_hale = false
+  manifesting_torch = false
+  manifesting_sharp = false
+  for tower in all(towers) do
+    if tower.position == manifest_location then
+      if (tower.name == "sword circle") then
+        --reenable the tower to act as normal
+      elseif (tower.name == "lightning lance") then
+        --reenable the tower to act as normal. If cursor color implementation is changed, change back to normal cursor. 
+      elseif (tower.name == "hale howitzer") then
+        --reenable the tower to act as normal. If cursor color implementation is changed, change back to normal cursor. 
+      elseif (tower.name == "torch trap") then
+        --For the Torch Trap, its position will be updated every frame and the original tower will be deleted as soon as manifestation start. 
+        --Ending manifestation will just place the torch trap wherever the cursor currently is.
       end
     end
   end
+end
+
+function manifested_lightning_blast()
+
+end
+
+function manifested_hale_blast()
+
 end
 
 function draw_tower_attack_overlay(tower_details)

--- a/src/updateLoops.lua
+++ b/src/updateLoops.lua
@@ -35,16 +35,36 @@ function game_loop()
   if (auto_start_wave) start_round()
 
   if btnp(🅾️) then
-    shop_enable = true
-    menus[1].enable = true
-    return
+    if manifesting_now == false then
+      shop_enable = true
+      menus[1].enable = true
+      return
+    else
+      unmanifest_tower()
+    end
   end
   if btnp(❎) then 
-    local position = selector.position/8
-    if is_in_table(position, towers, true) then 
-      refund_tower_at(position)
-    else
-      place_tower(position)
+    if manifesting_now == false then
+      local position = selector.position/8
+      if is_in_table(position, towers, true) then 
+        if manifest_mode == false then
+          refund_tower_at(position)
+        else
+          manifest_tower_at(position)
+        end
+      else
+        place_tower(position)
+      end
+    elseif manifesting_now == true then
+      if manifesting_sword then
+        -- X does nothing when manifesting the sword circle, unless we implement the easy version of the minigame.
+      elseif manifesting_lightning then
+        manifested_lightning_blast()
+      elseif manifesting_hale then
+        manifested_hale_blast()
+      elseif manifesting_torch then
+        -- X does nothing when manifesting the Torch trap unless we add some fancy extra functionality.
+      end
     end
   end
 


### PR DESCRIPTION
The game is now able to go to and from manifestation states. The game keeps track of what type of tower is being manifested, changes the game's controls so Z exits manifestation rather than opening a menu (and X calls functions depending on the manifestation). The coordinates of the tower being manifested are saved and there's a slot for defining special logic at the time of manifestation and unmanifestation based on the tower. Using this, I'm going to properly make the manifestation mode for the Hale Howitzer.